### PR TITLE
Add perimeter request in case of failure

### DIFF
--- a/assets/css/map.css
+++ b/assets/css/map.css
@@ -95,6 +95,7 @@ header {
 .show-localized-error,
 .show-roof,
 .show-no-roof,
+.show-no-roof-outside-perimeter,
 .show-heat,
 .show-heat-dg,
 .is-loading .trn {
@@ -110,6 +111,11 @@ header {
 .no-roof .show-no-roof {
   display: block;
 }
+
+.no-roof-outside-perimeter .show-no-roof-outside-perimeter {
+  display: block;
+}
+
 
 
 /* Correction template */

--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -39,7 +39,7 @@ var onAddressFound = function(map, marker, address, autoSearchRoof, roofSearchTo
     $(document.body).removeClass('address-found');
     $(document.body).addClass('no-address');
     if (autoSearchRoof) {
-      $(document.body).removeClass('roof no-roof');
+      $(document.body).removeClass('roof no-roof no-roof-outside-perimeter');
       clearHighlight(map, marker); 
     }
   }
@@ -162,7 +162,7 @@ var updateRoofInfo = function(map, marker, roof) {
   }
 
   //add css-class
-  $(document.body).removeClass('no-roof').addClass('roof');
+  $(document.body).removeClass('no-roof').removeClass('no-roof-outside-perimeter').addClass('roof');
   
   // check if no waermeertrag and if no dg_heizung
   var titleHeat = '';
@@ -312,7 +312,8 @@ var updateRoofInfo = function(map, marker, roof) {
  * Display the data of the roof selected
  */
 var onRoofFound = function(map, marker, roof, findBestRoof) {
-  if (roof) {
+  if (roof && roof.perimeter === undefined) {
+
     // Find best roof for given building
     if (findBestRoof) {
       searchBestRoofFromBuildingId(roof.attributes.building_id).then(function(roof) {
@@ -324,7 +325,11 @@ var onRoofFound = function(map, marker, roof, findBestRoof) {
   } else {
     // Clear the highlighted roof
     clearHighlight(map, marker);
-    $(document.body).removeClass('roof').addClass('no-roof');
+    if (!roof || roof.perimeter) {
+      $(document.body).removeClass('roof').removeClass('no-roof-outside-perimeter').addClass('no-roof');
+    } else {
+      $(document.body).removeClass('roof no-roof').removeClass('no-roof').addClass('no-roof-outside-perimeter');
+    }
   }
 }
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -19,7 +19,36 @@ var searchFeaturesFromCoord = function(map, coord, tolerance) {
   $(document.body).addClass('ajax-roof');
   return $.getJSON(url).then(function(data) {
     $(document.body).removeClass('ajax-roof');
-    return data;
+
+    if (!data.results[0]) {
+      var perimeterURL = API3_URL + '/rest/services/api/MapServer/identify?' + //url
+        'geometryType=esriGeometryPoint' +
+        '&returnGeometry=true' +
+        '&layers=all:ch.bfe.solarenergie-eignung-daecher' +
+        '&geometry=' + coord +
+        '&mapExtent=411600,55800,891600,330550' +
+        '&imageDisplay=1920,1099,96' +
+        '&tolerance=10' +
+        '&order=distance' +
+        '&lang=de';
+      return $.getJSON(perimeterURL).then(function(perimeterData) {
+        if (perimeterData.results[0]) {
+          return {results: [{
+            perimeter: true
+          }]};
+        } else {
+          return {results: [{
+            perimeter: false
+          }]}
+        }
+      });
+    } else if (data.results[0].featureId == -999) {
+      return {results: [{
+        perimeter: true
+      }]};
+    } else {
+      return data;
+    }
   });
 };
 

--- a/assets/js/translations.js
+++ b/assets/js/translations.js
@@ -63,6 +63,10 @@ var sdTranslations = {
     de: '<strong>An dieser Adresse konnte kein Dach gefunden werden.</strong> Momentan sind 50% des Gebäudebestandes erfasst; bis Anfang 2018 werden alle Hausdächer der Schweiz verfügbar sein.',
     fr: 'french no roof found'
   },
+  noRoofFoundOutsidePerimeter: {
+    de: '<strong>An dieser Adresse konnte kein Dach gefunden werden.</strong> Momentan sind 50% des Gebäudebestandes erfasst; bis Anfang 2018 werden alle Hausdächer der Schweiz verfügbar sein.',
+    fr: 'french no roof found'
+  },
   newAddress: {
     de: 'Neue Adresse suchen',
     fr: 'Neue Adresse suchen FR'

--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
             </header>
             <header class="major">
               <h4 class="hidden-localized trn">bittelokal</h4>
+              <h4 class="show-no-roof-outside-perimeter trn">noRoofFoundOutsidePerimeter</h4>
               <h4 class="show-no-roof trn">noRoofFound</h4>
               <h4 class="show-roof">
                 <ul class="actions uniform show-roof">


### PR DESCRIPTION
@cype This is the finalisation of the work I began 2 weeks ago.

It adds a perimeter check in case no roof could be found. This allows for a different information in the front-end if this is desired.

There's a new text (noRoofFoundOutsidePerimeter) for this which currently contains the same text as the noRoofFound text. I think it's safe to merge this and then you can adapt it according to your needs.
