### PR TITLE
Use layers Config service to get layers configuration

### DIFF
--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -513,73 +513,71 @@ var init = function(nointeraction) {
   }
 
   // Create map
-  var map = createMap('map', lang, nointeraction);
-  var marker = new ol.Overlay({
-    positioning:'bottom-center',
-    element: markerElt[0],
-    position: undefined,
-    stopEvent: false
-    //autoPan: true,
-    //autoPanMargin: 150 
-  });
-  map.addOverlay(marker);
-  map.on('singleclick', function(evt){
-    var coord = evt.coordinate;
-   
-    //Do roof search explicitely
-    searchFeaturesFromCoord(map, coord, 0.0).then(function(data) {
-      onRoofFound(map, marker, data.results[0], false); //???????
-      // We call the geocode function here to get the
-      // address information for the clicked point using
-      // the GWR layer.
-      // The false parameter indicates that geocode does
-      // not trigger a roof search.
-      // Relouch the roof search with the coordinate of address if necessary.
-      var relaunchRoofSearch = (data.results.length == 0);
-      geocode(map, coord).then(function(data) {
-        // We assume the first of the list is the closest
-        onAddressFound(map, marker, data.results[0], relaunchRoofSearch, 0.0);
+  createMap('map', lang, nointeraction).then(function(map) {;
+    var marker = new ol.Overlay({
+      positioning:'bottom-center',
+      element: markerElt[0],
+      position: undefined,
+      stopEvent: false
+    });
+    map.addOverlay(marker);
+    map.on('singleclick', function(evt){
+      var coord = evt.coordinate;
+      //Do roof search explicitely
+      searchFeaturesFromCoord(map, coord, 0.0).then(function(data) {
+        onRoofFound(map, marker, data.results[0], false); //???????
+        // We call the geocode function here to get the
+        // address information for the clicked point using
+        // the GWR layer.
+        // The false parameter indicates that geocode does
+        // not trigger a roof search.
+        // Relouch the roof search with the coordinate of address if necessary.
+        var relaunchRoofSearch = (data.results.length == 0);
+        geocode(map, coord).then(function(data) {
+          // We assume the first of the list is the closest
+          onAddressFound(map, marker, data.results[0], relaunchRoofSearch, 0.0);
+        });
       });
     });
-  });
 
-  // Init the search input
-  initSearch(map, marker, onAddressFound);
- 
-  // Init geoloaction button 
-  locationBt.click(function() {
-    body.removeClass('localized-error');
-    getLocation(map, marker, onAddressFound, function(msg) {
-      $(document.body).addClass('localized-error');
-      $('#locationError').html(msg);
-    });
-  });
+    // Init the search input
+    initSearch(map, marker, onAddressFound);
 
-  // Display the feature from permalink
-  if (permalink.featureId) {
-    searchFeatureFromId(permalink.featureId).then(function(data) {
-
-      var coord = ol.extent.getCenter(data.feature.bbox);
-      // Assure to be around resulting point with correct zoom level
-      map.getView().setCenter(coord);
-      map.getView().setResolution(0.25);
-
-      geocode(map, coord).then(function(data) {
-        // We assume the first of the list is the closest
-        onAddressFound(map, marker, data.results[0], false, 50.0);
+    // Init geoloaction button
+    locationBt.click(function() {
+      body.removeClass('localized-error');
+      getLocation(map, marker, onAddressFound, function(msg) {
+        $(document.body).addClass('localized-error');
+        $('#locationError').html(msg);
       });
-
-      goTo('one');
-      
-      // Add the featureId to the lang link href
-      $('#lang a').attr('href', function(index, attr) {
-        this.href = attr + '&featureId=' + permalink.featureId;
-      });
-
-      onRoofFound(map, marker, data.feature); //??????
-
     });
-  }
+
+    // Display the feature from permalink
+    if (permalink.featureId) {
+      searchFeatureFromId(permalink.featureId).then(function(data) {
+
+        var coord = ol.extent.getCenter(data.feature.bbox);
+        // Assure to be around resulting point with correct zoom level
+        map.getView().setCenter(coord);
+        map.getView().setResolution(0.25);
+
+        geocode(map, coord).then(function(data) {
+          // We assume the first of the list is the closest
+          onAddressFound(map, marker, data.results[0], false, 50.0);
+        });
+
+        goTo('one');
+
+        // Add the featureId to the lang link href
+        $('#lang a').attr('href', function(index, attr) {
+          this.href = attr + '&featureId=' + permalink.featureId;
+        });
+
+        onRoofFound(map, marker, data.feature); //??????
+
+      });
+    }
+  });
 
   if ($.contains(document.body, document.getElementById("socialTwitter"))) {
     document.getElementById("socialTwitter").href = 

--- a/assets/js/layers.js
+++ b/assets/js/layers.js
@@ -2,93 +2,11 @@
  * Get the layers configuartion
  * 
  * @method
- * @return {Object}
+ * @return {Promise}
  */
 var getLayersConfig = function(lang) {
-  return {
-    "ch.swisstopo.swissimage": {
-      "attribution": "CNES, Spot Image, swisstopo, NPOC",
-      "background": true,
-      "searchable": false,
-      "format": "jpeg",
-      "hasLegend": false,
-      "serverLayerName": "ch.swisstopo.swissimage",
-      "selectbyrectangle": false,
-      "attributionUrl": "http://www.swisstopo.admin.ch/internet/swisstopo/" + lang + "/home.html",
-      "timeBehaviour": "last",
-      "tooltip": false,
-      "label": "SWISSIMAGE",
-      "highlightable": true,
-      "chargeable": true,
-      "timestamps": [
-        "20151231",
-        "20140620",
-        "20131107",
-        "20130916",
-        "20130422",
-        "20120809",
-        "20120225",
-        "20110914",
-        "20110228"
-      ],
-      "topics": "api,swissmaponline",
-      "resolutions": [
-        4000,
-        3750,
-        3500,
-        3250,
-        3000,
-        2750,
-        2500,
-        2250,
-        2000,
-        1750,
-        1500,
-        1250,
-        1000,
-        750,
-        650,
-        500,
-        250,
-        100,
-        50,
-        20,
-        10,
-        5,
-        2.5,
-        2,
-        1.5,
-        1,
-        0.5,
-        0.25
-      ],
-      "type": "wmts",
-      "timeEnabled": false,
-      "queryable": false
-    },
-    "ch.bfe.solarenergie-eignung-daecher": {
-      "queryableAttributes": ["building_id","df_uid"],
-      "attribution": "BFE",
-      "background":false,
-      "searchable":false,
-      "format":"png",
-      "hasLegend":true,
-      "serverLayerName": "ch.bfe.solarenergie-eignung-daecher",
-      "selectbyrectangle":true,
-      "attributionUrl":"http://www.bfe.admin.ch/index.html?lang=de",
-      "timeBehaviour":"last",
-      "tooltip":true,
-      "label":"Solarenergie: Eignung D\u00e4cher",
-      "highlightable":true,
-      "chargeable":false,
-      "timestamps":["20160218"],
-      "topics":"api,dev,ech,energie,inspire,swissmaponline,wms-bgdi_prod",
-      "resolutions": [4000,3750,3500,3250,3000,2750,2500,2250,2000,1750,1500,1250,1000,750,650,500,250,100,50,20,10,5,2.5,2,1.5,1,0.5],
-      "type":"wmts",
-      "timeEnabled":false,
-      "queryable":true
-    }
-  };
+  var url = API3_URL + '/rest/services/api/MapServer/layersConfig?lang=' + lang;
+  return $.getJSON(url);
 };
 
 /**

--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -1,93 +1,95 @@
 /**
  * This function creates the map with all layers, interactions and controls
  *
- * returns an openlayers map
+ * returns a promise that resolves when the map is ready
  */
 var createMap = function(eltId, lang, nointeraction) {
 	
   // Create the layers
-  var layers = getLayersConfig(lang);
-  var layer1Id = 'ch.swisstopo.swissimage';
-  var layer1Config = layers[layer1Id];
-  var layer1 = new ol.layer.Tile({
-    minResolution: layer1Config.minResolution,
-    maxResolution: layer1Config.maxResolution,
-    opacity: layer1Config.opacity,
-    source: getWmts(layer1Id, layer1Config),
-    useInterimTilesOnError: false
-  })
-  var layer2Id = 'ch.bfe.solarenergie-eignung-daecher';
-  var layer2Config = layers[layer2Id];
-  var layer2 = new ol.layer.Tile({
-    minResolution: layer2Config.minResolution,
-    maxResolution: layer2Config.maxResolution,
-    opacity: layer2Config.opacity,
-    source: getWmts(layer2Id, layer2Config),
-    useInterimTilesOnError: false
-  })
-
-  // Display th highlight of the roof
-  var vector = new ol.layer.Vector({
-    source: new ol.source.Vector(),
-    style: new ol.style.Style({
-      //fill: new ol.style.Fill({
-      //  color: [255, 255, 255, 0.4]
-      //}),
-      stroke: new ol.style.Stroke({
-        color: [0, 0, 0, 0.7],
-        width: 4
-      })
+  return getLayersConfig(lang).then(function(layers) {
+    var layer1Id = 'ch.swisstopo.swissimage';
+    var layer1Config = layers[layer1Id];
+    var layer1 = new ol.layer.Tile({
+      minResolution: layer1Config.minResolution,
+      maxResolution: layer1Config.maxResolution,
+      opacity: layer1Config.opacity,
+      source: getWmts(layer1Id, layer1Config),
+      useInterimTilesOnError: false
     })
-  });
-	
-  // Create a the openlayer map
-  var extent = [420000, 30000, 900000, 350000];
-  var proj = ol.proj.get('EPSG:21781');
-  proj.setExtent(extent);
-  var interactions = ol.interaction.defaults();
-  if (nointeraction) {
-    interactions = ol.interaction.defaults({
-      altShiftDragRotate: false,
-      doubleClickZoom: false,
-      dragPan: false,
-      pinchRotate: false,
-      pinchZoom: false,
-      keyboard: false,
-      mouseWheelZoom: false,
-      shiftDragZoom: false
-    });
-  }
+    var layer2Id = 'ch.bfe.solarenergie-eignung-daecher';
+    var layer2Config = layers[layer2Id];
+    var layer2 = new ol.layer.Tile({
+      minResolution: layer2Config.minResolution,
+      maxResolution: layer2Config.maxResolution,
+      opacity: layer2Config.opacity,
+      source: getWmts(layer2Id, layer2Config),
+      useInterimTilesOnError: false
+    })
 
-  var map = new ol.Map({
-    target: eltId,
-    layers: [layer1, layer2, vector],
-    view: new ol.View({
-      resolutions: [
-        650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5, 0.25, 0.1
-      ],
-      extent: extent,
-      center: ol.extent.getCenter(extent),
-      projection: proj,
-      zoom: 0
-    }),
-    controls: ol.control.defaults({
-		  attributionOptions: ({
-		    collapsible: false
-		  })
-    }),
-    logo: false,
-    interactions: interactions
-  });
-  map.addControl(new ol.control.ScaleLine());
-  
-  // Change cursor's style when a roof is available
-  map.on('pointermove', function(evt) {
-    var isHoverLayer = map.forEachLayerAtPixel(evt.pixel, function() {
-      return true;
-    }, undefined, function(layer) {
-      return layer === layer2;
+    // Display th highlight of the roof
+    var vector = new ol.layer.Vector({
+      source: new ol.source.Vector(),
+      style: new ol.style.Style({
+        //fill: new ol.style.Fill({
+        //  color: [255, 255, 255, 0.4]
+        //}),
+        stroke: new ol.style.Stroke({
+          color: [0, 0, 0, 0.7],
+          width: 4
+        })
+      })
     });
-    map.getTargetElement().style.cursor = (isHoverLayer) ? 'pointer' : '';
-  });
-  return map;
+
+    // Create a the openlayer map
+    var extent = [420000, 30000, 900000, 350000];
+    var proj = ol.proj.get('EPSG:21781');
+    proj.setExtent(extent);
+    var interactions = ol.interaction.defaults();
+    if (nointeraction) {
+      interactions = ol.interaction.defaults({
+        altShiftDragRotate: false,
+        doubleClickZoom: false,
+        dragPan: false,
+        pinchRotate: false,
+        pinchZoom: false,
+        keyboard: false,
+        mouseWheelZoom: false,
+        shiftDragZoom: false
+      });
+    }
+
+    var map = new ol.Map({
+      target: eltId,
+      layers: [layer1, layer2, vector],
+      view: new ol.View({
+        resolutions: [
+          650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5, 0.25, 0.1
+        ],
+        extent: extent,
+        center: ol.extent.getCenter(extent),
+        projection: proj,
+        zoom: 0
+      }),
+      controls: ol.control.defaults({
+        attributionOptions: ({
+          collapsible: false
+        })
+      }),
+      logo: false,
+      interactions: interactions
+    });
+    map.addControl(new ol.control.ScaleLine());
+
+    // Change cursor's style when a roof is available
+    map.on('pointermove', function(evt) {
+      var isHoverLayer = map.forEachLayerAtPixel(evt.pixel, function() {
+        return true;
+      }, undefined, function(layer) {
+        return layer === layer2;
+      });
+      map.getTargetElement().style.cursor = (isHoverLayer) ? 'pointer' : '';
+    });
+    return map;
+  });;
+
 }


### PR DESCRIPTION
This PR changes the way we define the layers for the map in sonnendach.ch.

Before, the layers were defined directly in code. This as the disadvantage that updates to the layers definitions must be done by hand in the sonnendach code. For instance, when an update is created for the sonnendach layer, we have to adapt this page to get the newest data displayed.

With this PR, the definitions for the layers is coming directly from our API. With this, we are sure to always get the latest data in sonnendach ui. There's a little cost for this: initial page load is a little lower.

@oterral Quick review?

@cype Please test. I think it makes sense if you can live with a littler slower initial load. It would reduce maintenance and the risk to 'forget' something.
